### PR TITLE
Grid contents now align to the centre when viewport is squeezed.

### DIFF
--- a/src/components/search_page/SearchResults.tsx
+++ b/src/components/search_page/SearchResults.tsx
@@ -36,11 +36,10 @@ const Results = (props: Props) => {
     return (
         <>
             <Grid
-                alignContent="center"
                 gap="15px"
                 w="90%"
-                templateColumns="repeat(auto-fill,minmax(350px,1fr))"
-                templateRows="repeat(auto-fill,minmax(250px,1fr))"
+                justifyContent="center"
+                templateColumns="repeat(auto-fit, minmax(400px,max-content))"
                 >
                 {searchTerm != "" ? (
                     results?.map((group) => (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46620327/112758551-9bf86580-9021-11eb-9b65-b66452f7c864.png)
