### PR TITLE
Made groups card titles better

### DIFF
--- a/src/components/cards/GroupCard.tsx
+++ b/src/components/cards/GroupCard.tsx
@@ -66,7 +66,7 @@ const GroupCard = ({ group, groupID }: Props) => {
                 <Text textColor="gray.700" flex="auto" noOfLines={1}>
                     {group.description}
                 </Text>
-                <Heading fontSize="1.8rem" noOfLines={1}>
+                <Heading fontSize="1.5rem" noOfLines={1}>
                     {group.name}
                 </Heading>
             </Flex>

--- a/src/components/search_page/SearchResults.tsx
+++ b/src/components/search_page/SearchResults.tsx
@@ -44,7 +44,7 @@ const Results = (props: Props) => {
                 gap="15px"
                 w="90%"
                 justifyContent="center"
-                templateColumns="repeat(auto-fit, minmax(250px,max-content))"
+                templateColumns="repeat(auto-fit, 300px)"
             >
                 {allGroups.map((group) => (
                     <GroupCard


### PR DESCRIPTION
Reduce the size of Group Card Title font and set fixed sized of 300px for Group cards.